### PR TITLE
Official Alpine and adjust NGINX settings

### DIFF
--- a/servers/conf/nginx.conf
+++ b/servers/conf/nginx.conf
@@ -1,30 +1,29 @@
 user proxy;
-worker_processes  1;
- 
-error_log  /dev/stderr;
- 
-#pid /usr/local/nginx/run/nginx.pid;
- 
- 
+worker_processes 4;
+
+error_log /dev/stderr warn;
+
 events {
-    worker_connections  1024;
+    worker_connections 1024;
 }
- 
- 
+
 http {
-    access_log /dev/stdout;
- 
- 
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
+    types_hash_max_size 2048;
+    server_tokens off;
+    server_name_in_redirect off;
+
     include       mime.types;
     default_type  application/octet-stream;
- 
-    sendfile        on;
- 
-    keepalive_timeout  65;
- 
+
+    access_log off;
+
     include /usr/local/nginx/sites-enabled/*;
- 
+
     client_max_body_size 1024m;
     fastcgi_buffers      16  16k;
-    fastcgi_buffer_size  16k; 
+    fastcgi_buffer_size  16k;
 }


### PR DESCRIPTION
- Official Alpine image (alpine:3.3).
- A little bit improved image instruction, reduced size image from 232 MB till 216.3 MB
- Disabled access_log at all.
- Adjusted NGINX settings (basically i copied them from origin ADOP-Proxy).
