### PR TITLE
Updated base image version for security

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.3
+FROM alpine:3.8
 
 RUN apk --update add \
 		openssl-dev \


### PR DESCRIPTION
Having scanned the image using Anchore it flagged severl security vulnerabilities.
These are all remedied by updating the base image version to the latest.